### PR TITLE
Support bidirectional queue system

### DIFF
--- a/include/quakembd.h
+++ b/include/quakembd.h
@@ -58,13 +58,11 @@ typedef struct {
 } key_event_t;
 
 typedef struct {
-	int32_t xrel;
-	int32_t yrel;
+	int32_t xrel, yrel;
 } mouse_motion_t;
 
 typedef struct {
-	int32_t x;
-	int32_t y;
+	int32_t x, y;
 } mouse_movement_t;
 
 int qembd_get_width();


### PR DESCRIPTION
Use the newly introduced bidirectional system calls setup_queue and submit_queue to avoid crashing when launching the demo.