### PR TITLE
Support mouse relative mode via submission queue

### DIFF
--- a/port/boards/rv32emu/main.c
+++ b/port/boards/rv32emu/main.c
@@ -107,6 +107,17 @@ void qembd_udelay(uint32_t us)
 		end = qembd_get_us_time();
 }
 
+void qembd_set_relative_mode(bool enabled) {
+	submission_t submission;
+	submission.type = RELATIVE_MODE_SUBMISSION;
+	submission.mouse.enabled = enabled;
+	submission_queue.base[submission_queue.end++] = submission;
+	submission_queue.end &= queues_capacity - 1;
+	register int a0 asm("a0") = 1;
+	register int a7 asm("a7") = 0xfeed;
+	asm volatile("scall" : "+r"(a0) : "r"(a7));
+}
+
 int main(int c, char **v)
 {
 	void *base = malloc(sizeof(event_t) * queues_capacity + 
@@ -118,6 +129,7 @@ int main(int c, char **v)
 	register int a2 asm("a2") = (uintptr_t) (&event_count);
 	register int a7 asm("a7") = 0xc0de;
 	asm volatile("scall" : "+r"(a0) : "r"(a1), "r"(a2), "r"(a7));
+	qembd_set_relative_mode(true);
 	return qembd_main(c, v);
 }
 

--- a/winquake/menu.c
+++ b/winquake/menu.c
@@ -23,6 +23,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "winquake.h"
 #endif
 
+void qembd_set_relative_mode(bool enabled);
+
 void (*vid_menudrawfn)(void);
 void (*vid_menukeyfn)(int key);
 
@@ -287,6 +289,7 @@ int	m_main_cursor;
 
 void M_Menu_Main_f (void)
 {
+	qembd_set_relative_mode(false);
 	if (key_dest != key_menu)
 	{
 		m_save_demonum = cls.demonum;
@@ -321,6 +324,7 @@ void M_Main_Key (int key)
 		cls.demonum = m_save_demonum;
 		if (cls.demonum != -1 && !cls.demoplayback && cls.state != ca_connected)
 			CL_NextDemo ();
+		qembd_set_relative_mode(true);
 		break;
 
 	case K_DOWNARROW:
@@ -425,6 +429,7 @@ void M_SinglePlayer_Key (int key)
 				Cbuf_AddText ("disconnect\n");
 			Cbuf_AddText ("maxplayers 1\n");
 			Cbuf_AddText ("map start\n");
+			qembd_set_relative_mode(true);
 			break;
 
 		case 1:


### PR DESCRIPTION
This commit adds support for automatic mouse capture control via the new submission queue feature. With this modification, the cursor will be captured once the game screen become visible and be released when the menu is opened.