### PR TITLE
Synchronize with recent SDL-oriented system calls

### DIFF
--- a/include/quakembd.h
+++ b/include/quakembd.h
@@ -58,7 +58,7 @@ typedef struct {
 } key_event_t;
 
 typedef struct {
-	int32_t xrel, yrel;
+	int32_t x, y, xrel, yrel;
 } mouse_motion_t;
 
 typedef struct {

--- a/port/boards/rv32emu/main.c
+++ b/port/boards/rv32emu/main.c
@@ -32,6 +32,7 @@ enum {
 	KEY_EVENT = 0,
 	MOUSE_MOTION_EVENT = 1,
 	MOUSE_BUTTON_EVENT = 2,
+	QUIT_EVENT = 3,
 };
 
 typedef struct {
@@ -57,14 +58,23 @@ typedef struct {
 
 enum {
 	RELATIVE_MODE_SUBMISSION = 0,
+	WINDOW_TITLE_SUBMISSION = 1,
 };
+
+typedef struct {
+	uint8_t enabled;
+} mouse_submission_t;
+
+typedef struct {
+	uint32_t title;
+	uint32_t size;
+} title_submission_t;
 
 typedef struct {
 	uint32_t type;
 	union {
-		union {
-			uint8_t enabled;
-		} mouse;
+	   mouse_submission_t mouse;
+	   title_submission_t title;
 	};
 } submission_t;
 
@@ -262,6 +272,9 @@ int qembd_dequeue_key_event(key_event_t *e)
 					break;
 			}
 			return 0;
+		}
+		if (event.type == QUIT_EVENT) {
+			exit(0);
 		}
 	}
 	return -1;


### PR DESCRIPTION
This commit makes this repository compatible with the new version of rv32emu, which implements the features used by fenster-rv32emu. New features include window title customization, mouse position fetching and program quit event. Even though not all of the added features are used, the code must be updated because the patch doesn't have binary backward compatibility.